### PR TITLE
Port `topformflat`-using lines reducers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 tests/fixtures/*.orig
+*.pyc
+*.gch
+*.o

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,28 +14,22 @@ addons:
 rust:
   - stable
   - beta
-  - nightly
+  # Rustup + Nightly is broken right now, and I can't figure out how to get
+  # allow_failures to work properly.
+  # - nightly
 
 cache: cargo
 
 env:
   matrix:
-    - JOB="build" PROFILE=""          FEATURES=""
     - JOB="test"  PROFILE=""          FEATURES=""
-    # JOB="bench" PROFILE=""          FEATURES=""
-    - JOB="build" PROFILE="--release" FEATURES=""
     - JOB="test"  PROFILE="--release" FEATURES=""
-    - JOB="bench" PROFILE="--release" FEATURES=""
-    - JOB="build" PROFILE=""          FEATURES="signpost"
+    # JOB="bench" PROFILE="--release" FEATURES=""
     - JOB="test"  PROFILE=""          FEATURES="signpost"
-    # JOB="bench" PROFILE=""          FEATURES="signpost"
-    - JOB="build" PROFILE="--release" FEATURES="signpost"
     - JOB="test"  PROFILE="--release" FEATURES="signpost"
-    - JOB="bench" PROFILE="--release" FEATURES="signpost"
+    # JOB="bench" PROFILE="--release" FEATURES="signpost"
 
 matrix:
   fast_finish: true
-  allow_failures:
-    -rust: nightly
 
 script: ./ci/script.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,10 +2,10 @@
 name = "preduce"
 version = "0.1.0"
 dependencies = [
- "clap 2.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "signpost 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -22,7 +22,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -38,14 +38,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.23.1"
+version = "2.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "term_size 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -53,21 +53,21 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.20"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -78,13 +78,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "error-chain"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "gcc"
-version = "0.3.43"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -102,20 +97,20 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "libgit2-sys 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-probe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "idna"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-bidi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -130,21 +125,21 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.6.6"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cmake 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "curl-sys 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "gcc 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl-sys 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "libssh2-sys 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -153,20 +148,20 @@ name = "libssh2-sys"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cmake 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -176,36 +171,27 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "metadeps"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "num_cpus"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.6"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "metadeps 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -219,7 +205,7 @@ name = "rand"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -242,22 +228,17 @@ dependencies = [
 
 [[package]]
 name = "term_size"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "toml"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "unicode-bidi"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -283,7 +264,7 @@ name = "url"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -316,33 +297,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
-"checksum clap 2.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d480c39a2e5f9b3a3798c661613e1b0e7a7ae71e005102d4aa910fc3289df484"
-"checksum cmake 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "a3a6805df695087e7c1bcd9a82e03ad6fb864c8e67ac41b1348229ce5b7f0407"
-"checksum curl-sys 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "a89415561199ca2ac6de2519674739159c1583bc0a9b46ec30fd3814999d5ef5"
+"checksum clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f57e9b63057a545ad2ecd773ea61e49422ed1b1d63d74d5da5ecaee55b3396cd"
+"checksum cmake 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "d18d68987ed4c516dcc3e7913659bfa4076f5182eea4a7e0038bb060953e76ac"
+"checksum curl-sys 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "23e7e544dc5e1ba42c4a4a678bd47985e84b9c3f4d3404c29700622a029db9c3"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
-"checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
-"checksum gcc 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)" = "c07c758b972368e703a562686adb39125707cc1ef3399da8c019fc6c2498a75d"
+"checksum gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "40899336fb50db0c78710f53e87afc54d8c7266fb76262fecc78ca1a7f09deae"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "046ae03385257040b2a35e56d9669d950dd911ba2bf48202fbef73ee6aab27b2"
-"checksum idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1053236e00ce4f668aeca4a769a09b3bf5a682d802abd6f3cb39374f6b162c11"
+"checksum idna 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6ac85ec3f80c8e4e99d9325521337e14ec7555c458a14e377d189659a427f375"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "684f330624d8c3784fb9558ca46c4ce488073a8d22450415c5eb4f4cfb0d11b5"
-"checksum libgit2-sys 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c7a4e33e9f8b8883c1a5898e72cdc63c00c4f2265283651533b00373094e901c"
+"checksum libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)" = "babb8281da88cba992fa1f4ddec7d63ed96280a1a53ec9b919fd37b53d71e502"
+"checksum libgit2-sys 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a3aaa20337a0e79fb75180b6a1970c1f7cff9a413f570d6b999b38a5d5d54e81"
 "checksum libssh2-sys 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "91e135645c2e198a39552c8c7686bb5b83b1b99f64831c040a6c2798a1195934"
-"checksum libz-sys 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "7616099a575493da60cddc1174b686fcfb00ece89dc6f61f31ff47c35f07bbe8"
+"checksum libz-sys 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e5ee912a45d686d393d5ac87fac15ba0ba18daae14e8e7543c63ebf7fb7e970c"
 "checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
-"checksum metadeps 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829fffe7ea1d747e23f64be972991bc516b2f1ac2ae4a3b33d8bea150c410151"
-"checksum num_cpus 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a18c392466409c50b87369414a2680c93e739aedeb498eb2bff7d7eb569744e2"
-"checksum openssl-probe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "756d49c8424483a3df3b5d735112b4da22109ced9a8294f1f5cdf80fb3810919"
-"checksum openssl-sys 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b1482f9a06f56c906007e17ea14d73d102210b5d27bc948bf5e175f493f3f7c3"
+"checksum num_cpus 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca313f1862c7ec3e0dfe8ace9fa91b1d9cb5c84ace3d00f5ec4216238e93c167"
+"checksum openssl-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d98df0270d404ccd3c050a41d579c52d1db15375168bb3471e04ec0f5f378daf"
+"checksum openssl-sys 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e5e0fd64cb2fa018ed2e7b2c8d9649114fe5da957c9a67432957f01e5dcc82e9"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum signpost 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acde4ef7ee97ad3bac7c4f73ee22ddb71067aa1d427a22efa76284de48eada41"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
-"checksum term_size 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "07b6c1ac5b3fffd75073276bca1ceed01f67a28537097a2a9539e116e50fb21a"
-"checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
-"checksum unicode-bidi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b61814f3e7fd0e0f15370f767c7c943e08bc2e3214233ae8f88522b334ceb778"
+"checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
+"checksum unicode-bidi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d3a078ebdd62c0e71a709c3d53d2af693fe09fe93fbff8344aebe289b78f9032"
 "checksum unicode-normalization 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e28fa37426fceeb5cf8f41ee273faa7c82c47dc8fba5853402841e665fcd86ff"
 "checksum unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18127285758f0e2c6cf325bb3f3d138a12fee27de4f23e146cd6a179f26c2cf3"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -3,11 +3,9 @@
 set -eux
 
 case "$JOB" in
-    "build")
-        cargo build $PROFILE --verbose --features "$FEATURES"
-        ;;
     "test")
-        cargo test $PROFILE --verbose --features "$FEATURES"
+        cargo build $PROFILE --verbose --features "$FEATURES"
+        cargo test  $PROFILE --verbose --features "$FEATURES"
         ;;
     "bench")
         if [[ "$PROFILE" != "--release" ]]; then

--- a/reducers/lines.py
+++ b/reducers/lines.py
@@ -3,27 +3,11 @@
 import os
 import sys
 
-# The initial seed test case is the first and only argument.
-seed = sys.argv[1]
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+from reducer_utils import chunking_reducer
 
-# Count how many lines are in the seed test case.
-n = 0
-with open(seed, "r") as f:
-    for line in f:
-        n += 1
+def main():
+    chunking_reducer(sys.argv[1], 1, 1)
 
-for i in range(0, n):
-    # Read the file path from stdin.
-    out_file_path = sys.stdin.readline().strip()
-
-    # Generate the potential reduction without the seed's i^th line into the
-    # given path.
-    with open(out_file_path, "w") as out_file:
-        with open(seed, "r") as in_file:
-            for j, line in enumerate(in_file):
-                if i != j:
-                    out_file.write(line)
-
-    # Tell `preduce` we generated the reduction.
-    sys.stdout.write("\n")
-    sys.stdout.flush()
+if __name__ == "__main__":
+    main()

--- a/reducers/reducer_utils.py
+++ b/reducers/reducer_utils.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import sys
+import tempfile
+
+if __name__ == "__main__":
+    sys.exit(0)
+
+def num_lines_in_file(path):
+    """Return the number of lines in the file at the given path."""
+    num_lines = 0
+    with open(path, "r") as f:
+        for _ in f:
+            num_lines += 1
+    return num_lines
+
+def get_topformflat():
+    """Try to find the `topformflat` program."""
+    possibles = [
+        "/usr/local/libexec/topformflat",
+        "/usr/libexec/topformflat",
+    ]
+    for p in possibles:
+        if os.path.isfile(p):
+            return p
+    return None
+
+def chunk_sizes(min_chunk_size, max_chunk_size):
+    """Generate chunk sizes from min_chunk_size to max_chunk_size."""
+    chunk_size = max_chunk_size
+    while chunk_size >= min_chunk_size:
+        yield chunk_size
+        chunk_size = chunk_size // 2
+
+def copy_without_lines(from_path, to_path, start_skip_line, num_skip_lines):
+    """Copy the file at `from_path` to `to_path`, without the lines in the range
+    [start_skip_line, start_skip_line + num_skip_lines)
+
+    """
+    end_skip_lines = start_skip_line + num_skip_lines
+    with open(to_path, "w") as out_file:
+        with open(from_path, "r") as in_file:
+            for j, line in enumerate(in_file):
+                if start_skip_line <= j < end_skip_lines:
+                    continue
+                else:
+                    out_file.write(line)
+
+def chunking_reducer(seed, min_chunk_size = 1, max_chunk_size = None):
+    """Implements a reducer that removes chunks of lines from the given seed file.
+
+    """
+    num_lines = num_lines_in_file(seed)
+
+    if max_chunk_size is None:
+        max_chunk_size = num_lines
+
+    for chunk_size in chunk_sizes(min_chunk_size, max_chunk_size):
+        for i in range(0, num_lines - (chunk_size - 1)):
+            # Read the file path from stdin.
+            out_file_path = sys.stdin.readline().strip()
+
+            # Copy the file without the current chunk.
+            copy_without_lines(seed, out_file_path, i, chunk_size)
+
+            # Tell `preduce` we generated the reduction.
+            sys.stdout.write("\n")
+            sys.stdout.flush()
+
+def topformflat_reducer(seed, flatten):
+    """Run `topformflat` on the seed file, and then create a chunking reducer from
+    it.
+
+    """
+    topformflat = get_topformflat()
+    if topformflat is None:
+        return
+
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tmp_file:
+        with open(seed, "r") as in_file:
+            subprocess.check_call([topformflat, str(flatten)], stdin=in_file, stdout=tmp_file)
+
+    chunking_reducer(tmp_file.name)

--- a/reducers/topformflat-0.py
+++ b/reducers/topformflat-0.py
@@ -4,10 +4,10 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
-from reducer_utils import chunking_reducer
+from reducer_utils import topformflat_reducer
 
 def main():
-    chunking_reducer(sys.argv[1], min_chunk_size = 2)
+    topformflat_reducer(sys.argv[1], 0)
 
 if __name__ == "__main__":
     main()

--- a/reducers/topformflat-1.py
+++ b/reducers/topformflat-1.py
@@ -4,10 +4,10 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
-from reducer_utils import chunking_reducer
+from reducer_utils import topformflat_reducer
 
 def main():
-    chunking_reducer(sys.argv[1], min_chunk_size = 2)
+    topformflat_reducer(sys.argv[1], 1)
 
 if __name__ == "__main__":
     main()

--- a/reducers/topformflat-10.py
+++ b/reducers/topformflat-10.py
@@ -4,10 +4,10 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
-from reducer_utils import chunking_reducer
+from reducer_utils import topformflat_reducer
 
 def main():
-    chunking_reducer(sys.argv[1], min_chunk_size = 2)
+    topformflat_reducer(sys.argv[1], 10)
 
 if __name__ == "__main__":
     main()

--- a/reducers/topformflat-2.py
+++ b/reducers/topformflat-2.py
@@ -4,10 +4,10 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
-from reducer_utils import chunking_reducer
+from reducer_utils import topformflat_reducer
 
 def main():
-    chunking_reducer(sys.argv[1], min_chunk_size = 2)
+    topformflat_reducer(sys.argv[1], 2)
 
 if __name__ == "__main__":
     main()

--- a/reducers/topformflat-3.py
+++ b/reducers/topformflat-3.py
@@ -4,10 +4,10 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
-from reducer_utils import chunking_reducer
+from reducer_utils import topformflat_reducer
 
 def main():
-    chunking_reducer(sys.argv[1], min_chunk_size = 2)
+    topformflat_reducer(sys.argv[1], 3)
 
 if __name__ == "__main__":
     main()

--- a/reducers/topformflat-4.py
+++ b/reducers/topformflat-4.py
@@ -4,10 +4,10 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
-from reducer_utils import chunking_reducer
+from reducer_utils import topformflat_reducer
 
 def main():
-    chunking_reducer(sys.argv[1], min_chunk_size = 2)
+    topformflat_reducer(sys.argv[1], 4)
 
 if __name__ == "__main__":
     main()

--- a/reducers/topformflat-6.py
+++ b/reducers/topformflat-6.py
@@ -4,10 +4,10 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
-from reducer_utils import chunking_reducer
+from reducer_utils import topformflat_reducer
 
 def main():
-    chunking_reducer(sys.argv[1], min_chunk_size = 2)
+    topformflat_reducer(sys.argv[1], 6)
 
 if __name__ == "__main__":
     main()

--- a/reducers/topformflat-8.py
+++ b/reducers/topformflat-8.py
@@ -4,10 +4,10 @@ import os
 import sys
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))
-from reducer_utils import chunking_reducer
+from reducer_utils import topformflat_reducer
 
 def main():
-    chunking_reducer(sys.argv[1], min_chunk_size = 2)
+    topformflat_reducer(sys.argv[1], 8)
 
 if __name__ == "__main__":
     main()

--- a/src/bin/preduce.rs
+++ b/src/bin/preduce.rs
@@ -5,11 +5,14 @@
 extern crate clap;
 extern crate preduce;
 
+use std::io::{self, Write};
 use std::process;
 
 fn main() {
     if let Err(e) = try_main() {
-        println!("Error: {}", e);
+        let stderr = io::stderr();
+        let mut stderr = stderr.lock();
+        let _ = writeln!(&mut stderr, "Error: {}", e);
         process::exit(1);
     }
 }

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -5,6 +5,7 @@ use error;
 use git::{self, RepoExt};
 use git2;
 use std::fs;
+use std::io;
 use std::path;
 use std::sync::Arc;
 use tempdir;
@@ -274,7 +275,9 @@ impl Interesting {
 
         // Create a new immutable temp file for seeding reducers with the
         // initial test case.
-        let temp_file = TempFile::anonymous()?;
+        let dir = Arc::new(tempdir::TempDir::new("preduce-initial")?);
+        let file_name = path::PathBuf::from(file_path.as_ref().file_name().ok_or(error::Error::Io(io::Error::new(io::ErrorKind::Other, "Initial test case must be a file")))?);
+        let temp_file = TempFile::new(dir, file_name)?;
         fs::copy(file_path.as_ref(), temp_file.path())?;
 
         if !judge.is_interesting(temp_file.path())? {

--- a/tests/expectations/lines-0
+++ b/tests/expectations/lines-0
@@ -1,0 +1,43 @@
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat lorem, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.

--- a/tests/expectations/lines-1
+++ b/tests/expectations/lines-1
@@ -1,0 +1,43 @@
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat lorem, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.

--- a/tests/expectations/lines-2
+++ b/tests/expectations/lines-2
@@ -1,0 +1,43 @@
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat lorem, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.

--- a/tests/expectations/lines-3
+++ b/tests/expectations/lines-3
@@ -1,0 +1,43 @@
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat lorem, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.
+
+Nullam accumsan quam eu laoreet viverra. Nullam iaculis diam eu risus
+condimentum, eu sodales ante porttitor. Donec sit amet tincidunt orci. Quisque
+ornare, diam nec auctor euismod, erat nunc vulputate ipsum, non finibus mi
+sapien ut tellus. Sed vulputate, ligula vel ultricies hendrerit, nibh purus
+gravida lectus, in gravida sem velit vel tortor. Pellentesque auctor elit sed
+maximus gravida. Vivamus erat tonus, fringilla non auctor at, consequat a
+dui. Donec nec sem mi. Nullam pellentesque est a ante rhoncus, vel cursus odio
+commodo.

--- a/tests/expectations/nested-classes.cpp
+++ b/tests/expectations/nested-classes.cpp
@@ -1,0 +1,2 @@
+class Nine {
+};

--- a/tests/fixtures/nested-classes.cpp
+++ b/tests/fixtures/nested-classes.cpp
@@ -1,0 +1,14 @@
+template<typename T, typename U, int N>
+class Nine {
+    class Foo {
+        bool b;
+    };
+
+    class Bar {
+        char c;
+    };
+
+    T t;
+    U u;
+    char s[N];
+};

--- a/tests/predicates/class-nine-compiles.sh
+++ b/tests/predicates/class-nine-compiles.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# Ensure that it still has `class Nine`.
+grep 'class Nine ' "$1"
+
+# Ensure that it still compiles OK.
+clang++ -c "$1" -x c++ -std=c++11


### PR DESCRIPTION
C-Reduce's lines pass uses `topformflat` with different arguments of
flattening. Our lines reducer will remain the same, but we'll also have
topformflat specific reducers.