### PR TITLE
Run each reducer as its own actor

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,11 +1,5 @@
 reorder_imports = true
 reorder_imported_names = true
 write_mode = "Overwrite"
-
-# Style RFC Formatting
-fn_args_layout = "Block"
-array_layout = "Block"
-where_style = "Rfc"
-generics_indent = "Block"
-fn_call_style = "Block"
-trailing_comma = "Never"
+closure_block_indent_threshold = 0
+use_try_shorthand = true

--- a/src/actors/mod.rs
+++ b/src/actors/mod.rs
@@ -1,9 +1,11 @@
 //! Actors that orchestrate and perform the reduction search.
 
 mod logger;
+mod reducer;
 mod supervisor;
 mod worker;
 
 pub use self::logger::*;
+pub use self::reducer::*;
 pub use self::supervisor::*;
 pub use self::worker::*;

--- a/src/actors/reducer.rs
+++ b/src/actors/reducer.rs
@@ -1,0 +1,178 @@
+//! A reducer actor wraps a `preduce::traits::Reducer` trait object, allowing us
+//! to generate potential reductions from multiple reducers in parallel, and
+//! pipelined with each worker that is testing interestingness.
+
+use super::{Logger, Supervisor};
+use error;
+use signposts;
+use std::fmt;
+use std::panic;
+use std::sync::mpsc;
+use std::thread;
+use test_case;
+use traits;
+
+/// An identifier for a reducer actor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ReducerId(usize);
+
+impl ReducerId {
+    pub fn new(id: usize) -> ReducerId {
+        ReducerId(id)
+    }
+}
+
+impl fmt::Display for ReducerId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Messages that can be sent to reducer actors.
+#[derive(Debug)]
+enum ReducerMessage {
+    Shutdown,
+    RequestNextReduction,
+    SetNewSeed(test_case::Interesting),
+}
+
+/// A client handle to a reducer actor.
+#[derive(Clone, Debug)]
+pub struct Reducer {
+    id: ReducerId,
+    sender: mpsc::Sender<ReducerMessage>,
+}
+
+/// Reducer client API.
+impl Reducer {
+    /// Spawn a new reducer actor.
+    pub fn spawn(
+        id: ReducerId,
+        reducer: Box<traits::Reducer>,
+        supervisor: Supervisor,
+        logger: Logger,
+    ) -> error::Result<Reducer> {
+        logger.spawning_reducer(id);
+
+        let (sender, receiver) = mpsc::channel();
+
+        let me = Reducer { id, sender: sender };
+        let me2 = me.clone();
+
+        thread::Builder::new()
+            .name(format!("preduce-reducer-{:?}", reducer))
+            .spawn(move || {
+                ReducerActor::run(id, me2, reducer, receiver, supervisor, logger);
+            })?;
+
+        Ok(me)
+    }
+
+    /// Get this reducer's ID.
+    pub fn id(&self) -> ReducerId {
+        self.id
+    }
+
+    // For communication with this reducer from the supervisor, don't unwrap the
+    // mpsc sends. Instead of panicking the supervisor, let the catch_unwind'ing
+    // of the reducer inform the supervisor of a reducer's early, unexpected
+    // demise.
+
+    /// Tell this reducer to shutdown.
+    pub fn shutdown(self) {
+        let _ = self.sender.send(ReducerMessage::Shutdown);
+    }
+
+    /// Send the reducer the response to its request for another potential
+    /// reduction.
+    pub fn request_next_reduction(&self) {
+        let _ = self.sender.send(ReducerMessage::RequestNextReduction);
+    }
+
+    /// Reseed this reducer actor with the given test case.
+    pub fn set_new_seed(&self, new_seed: test_case::Interesting) {
+        let _ = self.sender.send(ReducerMessage::SetNewSeed(new_seed));
+    }
+}
+
+// Reducer actor implementation.
+
+struct ReducerActor {
+    me: Reducer,
+    reducer: Box<traits::Reducer>,
+    incoming: mpsc::Receiver<ReducerMessage>,
+    supervisor: Supervisor,
+    logger: Logger,
+}
+
+impl fmt::Debug for ReducerActor {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ReducerActor")
+    }
+}
+
+impl ReducerActor {
+    fn run(
+        id: ReducerId,
+        me: Reducer,
+        reducer: Box<traits::Reducer>,
+        incoming: mpsc::Receiver<ReducerMessage>,
+        supervisor: Supervisor,
+        logger: Logger,
+    ) {
+        let supervisor2 = supervisor.clone();
+        match {
+            let actor = ReducerActor {
+                me,
+                reducer,
+                incoming,
+                supervisor,
+                logger,
+            };
+            panic::catch_unwind(panic::AssertUnwindSafe(move || actor.run_loop()))
+        } {
+            Err(p) => {
+                supervisor2.reducer_panicked(id, p);
+            }
+            Ok(()) => {}
+        }
+    }
+
+    fn run_loop(mut self) {
+        self.logger.spawned_reducer(self.me.id);
+
+        for msg in self.incoming {
+            match msg {
+                ReducerMessage::Shutdown => {
+                    self.logger.shutdown_reducer(self.me.id);
+                    return;
+                }
+                ReducerMessage::SetNewSeed(new_seed) => {
+                    self.reducer.set_seed(new_seed);
+                }
+                ReducerMessage::RequestNextReduction => {
+                    let _signpost = signposts::ReducerNextReduction::new();
+
+                    self.logger.start_generating_next_reduction(self.me.id);
+                    match self.reducer.next_potential_reduction() {
+                        Err(e) => {
+                            // Log the error and tell the supervisor we are out
+                            // of reductions until the next seed test case.
+                            self.logger.reducer_errored(self.me.id, e);
+                            self.supervisor.no_more_reductions(self.me.clone());
+                        }
+                        Ok(None) => {
+                            self.logger.no_more_reductions(self.me.id);
+                            self.supervisor.no_more_reductions(self.me.clone());
+                        }
+                        Ok(Some(reduction)) => {
+                            self.logger.finish_generating_next_reduction(self.me.id);
+                            self.supervisor
+                                .reply_next_reduction(self.me.clone(), reduction);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/actors/supervisor.rs
+++ b/src/actors/supervisor.rs
@@ -1,13 +1,14 @@
 //! The supervisor actor manages workers, and brokers their access to new
 //! reductions.
 
-use super::{Logger, Worker, WorkerId};
+use super::{Logger, Reducer, ReducerId, Worker, WorkerId};
 use super::super::Options;
 use error;
 use git::{self, RepoExt};
 use signposts;
 use std::any::Any;
-use std::collections::HashMap;
+use std::cmp;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::io;
 use std::path;
@@ -19,44 +20,49 @@ use traits;
 /// The messages that can be sent to the supervisor actor.
 #[derive(Debug)]
 enum SupervisorMessage {
-    RequestNextReduction(Worker),
+    // From workers.
     WorkerPanicked(WorkerId, Box<Any + Send + 'static>),
     WorkerErrored(WorkerId, error::Error),
-    ReportInteresting(Worker, path::PathBuf, test_case::Interesting)
+    RequestNextReduction(Worker),
+    ReportInteresting(Worker, path::PathBuf, test_case::Interesting),
+
+    // From reducers.
+    ReducerPanicked(ReducerId, Box<Any + Send + 'static>),
+    ReplyNextReduction(Reducer, Option<test_case::PotentialReduction>),
 }
 
 /// A client handle to the supervisor actor.
 #[derive(Clone, Debug)]
 pub struct Supervisor {
-    sender: mpsc::Sender<SupervisorMessage>
+    sender: mpsc::Sender<SupervisorMessage>,
 }
 
 /// Supervisor client API.
 impl Supervisor {
     /// Spawn the supervisor thread, which will in turn spawn workers and start
     /// the test case reduction process.
-    pub fn spawn<I, R>(opts: Options<I, R>,)
-        -> error::Result<(Supervisor, thread::JoinHandle<error::Result<()>>)>
+    pub fn spawn<I>(
+        opts: Options<I>,
+    ) -> error::Result<(Supervisor, thread::JoinHandle<error::Result<()>>)>
     where
         I: 'static + traits::IsInteresting,
-        R: 'static + traits::Reducer,
     {
         let (sender, receiver) = mpsc::channel();
         let sender2 = sender.clone();
 
         let handle = thread::Builder::new()
             .name(format!("preduce-supervisor"))
-            .spawn(
-                move || {
-                    let supervisor = Supervisor { sender: sender2 };
-                    SupervisorActor::run(opts, supervisor, receiver)
-                }
-            )?;
+            .spawn(move || {
+                let supervisor = Supervisor { sender: sender2 };
+                SupervisorActor::run(opts, supervisor, receiver)
+            })?;
 
         let sup = Supervisor { sender: sender };
 
         Ok((sup, handle))
     }
+
+    // Messages sent to the supervisor from the workers.
 
     /// Request the next potentially-interesting test case reduction. The
     /// response will be sent back to the `who` worker.
@@ -89,41 +95,77 @@ impl Supervisor {
         interesting: test_case::Interesting,
     ) {
         self.sender
-            .send(SupervisorMessage::ReportInteresting(who, downstream, interesting))
+            .send(SupervisorMessage::ReportInteresting(
+                who,
+                downstream,
+                interesting,
+            ))
+            .unwrap();
+    }
+
+    // Messages sent to the supervisor from the reducer actors.
+
+    /// Notify the supervisor that the reducer with the given id panicked.
+    pub fn reducer_panicked(&self, id: ReducerId, panic: Box<Any + Send + 'static>) {
+        self.sender
+            .send(SupervisorMessage::ReducerPanicked(id, panic))
+            .unwrap();
+    }
+
+    /// Tell the supervisor that there are no more reductions of the current
+    /// test case.
+    pub fn no_more_reductions(&self, reducer: Reducer) {
+        self.sender
+            .send(SupervisorMessage::ReplyNextReduction(reducer, None))
+            .unwrap();
+    }
+
+    /// Give the supervisor the requested next reduction of the current test
+    /// case.
+    pub fn reply_next_reduction(&self, reducer: Reducer, reduction: test_case::PotentialReduction) {
+        self.sender
+            .send(SupervisorMessage::ReplyNextReduction(
+                reducer,
+                Some(reduction),
+            ))
             .unwrap();
     }
 }
 
 // Supervisor actor implementation.
 
-struct SupervisorActor<I, R>
+struct SupervisorActor<I>
 where
     I: 'static + traits::IsInteresting,
-    R: 'static + traits::Reducer,
 {
-    opts: Options<I, R>,
+    opts: Options<I>,
     me: Supervisor,
     logger: Logger,
     logger_handle: thread::JoinHandle<()>,
     repo: git::TempRepo,
     worker_id_counter: usize,
-    workers: HashMap<WorkerId, Worker>
+    workers: HashMap<WorkerId, Worker>,
+    idle_workers: Vec<Worker>,
+    reducers: HashMap<ReducerId, Reducer>,
+    exhausted_reducers: HashSet<ReducerId>,
+    reduction_queue: VecDeque<(test_case::PotentialReduction, ReducerId)>,
 }
 
-impl<I, R> SupervisorActor<I, R>
+impl<I> SupervisorActor<I>
 where
     I: 'static + traits::IsInteresting,
-    R: 'static + traits::Reducer,
 {
     fn run(
-        opts: Options<I, R>,
+        opts: Options<I>,
         me: Supervisor,
         incoming: mpsc::Receiver<SupervisorMessage>,
     ) -> error::Result<()> {
         let repo = git::TempRepo::new("preduce-supervisor")?;
 
         let num_workers = opts.num_workers();
+        let num_reducers = opts.reducers().len();
         let (logger, logger_handle) = Logger::spawn(fs::File::create("preduce.log")?)?;
+
         let mut supervisor = SupervisorActor {
             opts: opts,
             me: me,
@@ -131,13 +173,19 @@ where
             logger_handle: logger_handle,
             repo: repo,
             worker_id_counter: 0,
-            workers: HashMap::with_capacity(num_workers)
+            workers: HashMap::with_capacity(num_workers),
+            idle_workers: Vec::with_capacity(num_workers),
+            reducers: HashMap::with_capacity(num_reducers),
+            exhausted_reducers: HashSet::with_capacity(num_reducers),
+            reduction_queue: VecDeque::with_capacity(num_reducers),
         };
 
         supervisor.backup_original_test_case()?;
-
+        supervisor.spawn_reducers()?;
         supervisor.spawn_workers()?;
+
         let initial_interesting = supervisor.verify_initially_interesting()?;
+        supervisor.reseed_reducers(&initial_interesting);
         supervisor.run_loop(incoming, initial_interesting)
     }
 
@@ -155,6 +203,7 @@ where
 
         for msg in incoming {
             match msg {
+                // Messages from workers...
                 SupervisorMessage::WorkerErrored(id, err) => {
                     self.logger.worker_errored(id, err);
                     self.restart_worker(id)?;
@@ -166,27 +215,56 @@ where
                 }
 
                 SupervisorMessage::RequestNextReduction(who) => {
-                    self.send_next_reduction_to(who)?;
+                    self.enqueue_worker_for_reduction(who);
                 }
 
                 SupervisorMessage::ReportInteresting(who, downstream, interesting) => {
                     self.handle_new_interesting_test_case(
-                            who,
-                            downstream,
-                            orig_size,
-                            &mut smallest_interesting,
-                            interesting
-                        )?;
+                        who,
+                        downstream,
+                        orig_size,
+                        &mut smallest_interesting,
+                        interesting,
+                    )?;
+                }
+
+                // Messages from reducer actors...
+
+                // FIXME: Unlike workers, we don't currently have an easy way to
+                // restart reducers, so treat reducer failures as fatal. There
+                // isn't any inherent reason why we can't restart reducers,
+                // however, we just need to write the glue code that clones
+                // `Reducer` trait objects and all of that.
+                SupervisorMessage::ReducerPanicked(id, panic) => {
+                    self.logger.reducer_panicked(id, panic);
+                    return Err(error::Error::ReducerActorPanicked);
+                }
+
+                SupervisorMessage::ReplyNextReduction(reducer, None) => {
+                    assert!(self.reducers.contains_key(&reducer.id()));
+                    self.exhausted_reducers.insert(reducer.id());
+                }
+
+                SupervisorMessage::ReplyNextReduction(reducer, Some(reduction)) => {
+                    assert!(self.reducers.contains_key(&reducer.id()));
+                    self.reduction_queue.push_back((reduction, reducer.id()));
+                    self.drain_queues();
+                }
+            }
+
+            // If all of our reducers are exhausted, and we are out of potential
+            // reductions to test, then shutdown any idle workers, since we
+            // don't have any work for them.
+            if self.exhausted_reducers.len() == self.reducers.len() &&
+                self.reduction_queue.is_empty()
+            {
+                for worker in self.idle_workers.drain(..) {
+                    self.workers.remove(&worker.id());
+                    worker.shutdown();
                 }
             }
 
             if self.workers.is_empty() {
-                assert!(
-                    self.opts
-                        .reducer()
-                        .next_potential_reduction()?
-                        .is_none()
-                );
                 break;
             }
         }
@@ -200,10 +278,21 @@ where
         smallest_interesting: test_case::Interesting,
         orig_size: u64,
     ) -> error::Result<()> {
+        assert!(self.workers.is_empty());
+        assert!(self.reduction_queue.is_empty());
+        assert_eq!(self.exhausted_reducers.len(), self.reducers.len());
+
         let _signpost = signposts::SupervisorShutdown::new();
 
         self.logger
             .final_reduced_size(smallest_interesting.size(), orig_size);
+
+        // Tell all the reducer actors to shutdown, and then wait for them
+        // finish their cleanup by joining the logger thread, which exits once
+        // log messages can no longer be sent to it.
+        for (_, r) in self.reducers {
+            r.shutdown();
+        }
         drop(self.logger);
         self.logger_handle.join()?;
 
@@ -228,25 +317,40 @@ where
 
     /// Generate the next reduction and send it to the given worker, or shutdown
     /// the worker if our reducer is exhausted.
-    fn send_next_reduction_to(&mut self, who: Worker) -> error::Result<()> {
+    fn enqueue_worker_for_reduction(&mut self, who: Worker) {
         assert!(self.workers.contains_key(&who.id()));
 
-        let _signpost = signposts::SupervisorNextReduction::new();
-        self.logger.start_generating_next_reduction();
+        self.idle_workers.push(who);
+        self.drain_queues();
+    }
 
-        if let Some(reduction) = self.opts.reducer().next_potential_reduction()? {
-            self.logger.finish_generating_next_reduction();
-            who.next_reduction(reduction);
-        } else {
-            self.logger.no_more_reductions();
+    /// Given that either we've generated new potential reductions to test, or a
+    /// worker just became ready to test queued reductions, dispatch as many
+    /// reductions to workers as possible.
+    fn drain_queues(&mut self) {
+        assert!(
+            self.idle_workers.len() > 0 || self.reduction_queue.len() > 0,
+            "Should only call drain_queues when we have potential to do new work"
+        );
 
-            let old_worker = self.workers.remove(&who.id());
-            assert!(old_worker.is_some());
+        let num_to_drain = cmp::min(self.idle_workers.len(), self.reduction_queue.len());
+        let workers = self.idle_workers.drain(..num_to_drain);
+        let reductions = self.reduction_queue.drain(..num_to_drain);
 
-            who.shutdown();
+        for (worker, (reduction, reducer_id)) in workers.zip(reductions) {
+            assert!(self.workers.contains_key(&worker.id()));
+            assert!(self.reducers.contains_key(&reducer_id));
+
+            // Send the worker the next reduction from the queue to test for
+            // interestingness.
+            worker.next_reduction(reduction);
+
+            // And pipeline the worker's is-interesting test with generating the
+            // next reduction.
+            if !self.exhausted_reducers.contains(&reducer_id) {
+                self.reducers[&reducer_id].request_next_reduction();
+            }
         }
-
-        Ok(())
     }
 
     /// Given that the `who` worker just found a new interesting test case,
@@ -282,15 +386,33 @@ where
             self.repo
                 .fetch_and_reset_hard(downstream, smallest_interesting.commit_id())?;
 
-            // Third, re-seed our reducer with the new test case, send new work
-            // to the reporting worker, and respawn any workers that might have
-            // shutdown because we exhausted all possible reductions on the
-            // previous smallest interesting test case.
-            self.opts
-                .reducer()
-                .set_seed(smallest_interesting.clone());
-            self.send_next_reduction_to(who)?;
+            // Third, re-seed our reducer actors with the new test case, and
+            // respawn any workers that might have shutdown because we exhausted
+            // all possible reductions on the previous smallest interesting test
+            // case.
+            self.reseed_reducers(smallest_interesting);
             self.spawn_workers()?;
+
+            // Fourth, clear out any queued potential reductions that are larger
+            // than our new smallest interesting test case. We don't want to
+            // waste time on them. For any reduction we don't end up
+            // considering, tell its progenitor to generate its next reduction
+            // from the new seed.
+            {
+                let reducers = &self.reducers;
+                self.reduction_queue.retain(|&(ref reduction, reducer_id)| {
+                    if reduction.size() < new_size {
+                        return true;
+                    }
+
+                    reducers[&reducer_id].request_next_reduction();
+                    false
+                });
+            }
+
+            // Finaly send a new reduction to the worker that reported the new
+            // smallest test case.
+            self.enqueue_worker_for_reduction(who);
         } else {
             // Although the test case is interesting, it is not smaller. Tell
             // the worker to try and merge it with our current smallest
@@ -299,7 +421,7 @@ where
             // abandon this thread of traversal.
             self.logger.is_not_smaller(interesting.provenance().into());
             if !self.opts.should_try_merging() || interesting.provenance() == "merge" {
-                self.send_next_reduction_to(who)?;
+                self.enqueue_worker_for_reduction(who);
             } else {
                 who.try_merge(old_size, self.repo.head_id()?);
             }
@@ -318,15 +440,13 @@ where
             .file_name()
             .and_then(|s| s.to_str())
             .map(|s| s.to_string())
-            .ok_or_else(
-                || {
-                    let e = io::Error::new(
-                        io::ErrorKind::Other,
-                        "test case path must exist and representable in utf-8"
-                    );
-                    error::Error::TestCaseBackupFailure(e)
-                }
-            )?;
+            .ok_or_else(|| {
+                let e = io::Error::new(
+                    io::ErrorKind::Other,
+                    "test case path must exist and representable in utf-8",
+                );
+                error::Error::TestCaseBackupFailure(e)
+            })?;
         file_name.push_str(".orig");
         backup_path.set_file_name(file_name);
 
@@ -344,11 +464,9 @@ where
         let initial = test_case::Interesting::initial(
             &self.opts.test_case,
             self.opts.predicate(),
-            &self.repo
+            &self.repo,
         )?;
-        let initial = initial
-            .ok_or(error::Error::InitialTestCaseNotInteresting)?;
-        self.opts.reducer().set_seed(initial.clone());
+        let initial = initial.ok_or(error::Error::InitialTestCaseNotInteresting)?;
         Ok(initial)
     }
 
@@ -358,24 +476,52 @@ where
         assert!(self.workers.len() <= self.opts.num_workers());
 
         let new_workers: error::Result<Vec<_>> = (self.workers.len()..self.opts.num_workers())
-            .map(
-                |_| {
-                    let id = WorkerId::new(self.worker_id_counter);
-                    self.worker_id_counter += 1;
+            .map(|_| {
+                let id = WorkerId::new(self.worker_id_counter);
+                self.worker_id_counter += 1;
 
-                    let worker = Worker::spawn(
-                        id,
-                        self.opts.predicate().clone(),
-                        self.me.clone(),
-                        self.logger.clone(),
-                        self.repo.path()
-                    )?;
-                    Ok((id, worker))
-                }
-            )
+                let worker = Worker::spawn(
+                    id,
+                    self.opts.predicate().clone(),
+                    self.me.clone(),
+                    self.logger.clone(),
+                    self.repo.path(),
+                )?;
+                Ok((id, worker))
+            })
             .collect();
         let new_workers = new_workers?;
         self.workers.extend(new_workers);
         Ok(())
+    }
+
+    /// Spawn a reducer actor for each reducer given to us in the options.
+    fn spawn_reducers(&mut self) -> error::Result<()> {
+        let reducers = self.opts.take_reducers();
+        for (i, reducer) in reducers.into_iter().enumerate() {
+            let id = ReducerId::new(i);
+            let reducer_actor = Reducer::spawn(id, reducer, self.me.clone(), self.logger.clone())?;
+            self.reducers.insert(id, reducer_actor);
+            self.exhausted_reducers.insert(id);
+        }
+        Ok(())
+    }
+
+    /// Reseed each of the reducer actors with the new smallest interesting test
+    /// case.
+    fn reseed_reducers(&mut self, smallest_interesting: &test_case::Interesting) {
+        for (id, reducer_actor) in &self.reducers {
+            reducer_actor.set_new_seed(smallest_interesting.clone());
+
+            // If the reducer was exhausted, put it back to work again by
+            // requesting the next reduction. If it isn't exhausted, then we
+            // will request its next reduction after we pull its most recently
+            // generated (or currently being generated) reduction from the
+            // reduction queue.
+            if self.exhausted_reducers.contains(id) {
+                reducer_actor.request_next_reduction();
+                self.exhausted_reducers.remove(id);
+            }
+        }
     }
 }

--- a/src/bin/preduce.rs
+++ b/src/bin/preduce.rs
@@ -26,19 +26,21 @@ fn parse_args() -> clap::ArgMatches<'static> {
         .arg(
             clap::Arg::with_name("test-case")
                 .required(true)
-                .help("The initial test case to reduce.")
+                .help("The initial test case to reduce."),
         )
         .arg(
             clap::Arg::with_name("predicate")
                 .required(true)
-                .help("The is-interesting predicate script.")
+                .help("The is-interesting predicate script."),
         )
         .arg(
             clap::Arg::with_name("reducer")
                 .required(true)
                 .multiple(true)
                 .min_values(1)
-                .help("The reduction generator scripts. There must be at least one.")
+                .help(
+                    "The reduction generator scripts. There must be at least one.",
+                ),
         )
         .arg(
             clap::Arg::with_name("workers")
@@ -46,26 +48,24 @@ fn parse_args() -> clap::ArgMatches<'static> {
                 .long("workers")
                 .takes_value(true)
                 .value_name("NUM_WORKERS")
-                .validator(
-                    |a| {
-                        let num = a.parse::<usize>().map_err(|e| format!("{}", e))?;
-                        if num > 0 {
-                            Ok(())
-                        } else {
-                            Err("NUM_WORKERS must be a number greater than 0".into())
-                        }
+                .validator(|a| {
+                    let num = a.parse::<usize>().map_err(|e| format!("{}", e))?;
+                    if num > 0 {
+                        Ok(())
+                    } else {
+                        Err("NUM_WORKERS must be a number greater than 0".into())
                     }
-                )
+                })
                 .help(
                     "Set the number of parallel workers. Defaults to the number of logical \
-                     CPUs."
-                )
+                     CPUs.",
+                ),
         )
         .arg(
             clap::Arg::with_name("no_merging")
                 .short("n")
                 .long("no-merging")
-                .help("Do not attempt to do merges of interesting test cases.")
+                .help("Do not attempt to do merges of interesting test cases."),
         )
         .get_matches()
 }
@@ -76,38 +76,19 @@ fn try_main() -> error::Result<()> {
     let predicate = args.value_of("predicate").unwrap();
     let predicate = interesting::Script::new(predicate)?;
 
-    let mut reducers = args.values_of("reducer").unwrap();
-    let reducer = match (reducers.next(), reducers.next()) {
-        (Some(r), None) => Box::new(reducers::Script::new(r)?) as Box<traits::Reducer>,
-        (Some(r1), Some(r2)) => {
-            let r1 = reducers::Script::new(r1)?;
-            let r1 = reducers::Fuse::new(r1);
-
-            let r2 = reducers::Script::new(r2)?;
-            let r2 = reducers::Fuse::new(r2);
-
-            let init = Box::new(reducers::Chain::new(r1, r2));
-            let init = init as Box<traits::Reducer>;
-
-            let chained: error::Result<Box<traits::Reducer>> =
-                reducers.fold(Ok(init), |acc, r| {
-                    let acc = acc?;
-
-                    let script = reducers::Script::new(r)?;
-                    let script = reducers::Fuse::new(script);
-
-                    let chained = reducers::Chain::new(acc, script);
-                    Ok(Box::new(chained) as Box<traits::Reducer>)
-                });
-            chained?
-        }
-        _ => unreachable!(),
-    };
-    let reducer = reducers::LazilyReseed::new(reducer);
+    let reducers = args.values_of("reducer")
+        .unwrap()
+        .map(|script| {
+            let reducer = reducers::Script::new(script)?;
+            let reducer = reducers::Fuse::new(reducer);
+            let reducer = reducers::LazilyReseed::new(reducer);
+            Ok(Box::new(reducer) as Box<traits::Reducer>)
+        })
+        .collect::<error::Result<Vec<_>>>()?;
 
     let test_case = args.value_of("test-case").unwrap();
 
-    let mut options = preduce::Options::new(predicate, reducer, test_case);
+    let mut options = preduce::Options::new(predicate, reducers, test_case);
 
     if let Some(num_workers) = args.value_of("workers") {
         let num_workers = num_workers.parse::<usize>().unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,10 @@ pub enum Error {
     /// A panicked thread's failure value.
     Thread(Box<Any + Send + 'static>),
 
+    /// An unexpected panic occurred in a reducer actor. This should be
+    /// recoverable, but is not at the moment.
+    ReducerActorPanicked,
+
     /// An error related to a misbehaving reducer script.
     MisbehavingReducerScript(String),
 
@@ -38,6 +42,7 @@ impl fmt::Display for Error {
             Error::Git(ref e) => fmt::Display::fmt(e, f),
             Error::Io(ref e) => fmt::Display::fmt(e, f),
             Error::Thread(ref e) => write!(f, "Thread panicked: {:?}", e),
+            Error::ReducerActorPanicked => write!(f, "A reducer actor panicked"),
             Error::MisbehavingReducerScript(ref details) => {
                 write!(f, "Misbehaving reducer script: {}", details)
             }
@@ -63,9 +68,12 @@ impl error::Error for Error {
             Error::Git(ref e) => error::Error::description(e),
             Error::Io(ref e) => error::Error::description(e),
             Error::Thread(_) => "A panicked thread",
+            Error::ReducerActorPanicked => "A reducer actor panicked",
             Error::MisbehavingReducerScript(_) => "Misbehaving reducer script",
             Error::TestCaseBackupFailure(_) => "Could not backup initial test case",
-            Error::InitialTestCaseNotInteresting => "The initial test case did not pass the is-interesting predicate",
+            Error::InitialTestCaseNotInteresting => {
+                "The initial test case did not pass the is-interesting predicate"
+            }
             Error::DoesNotExist(_) => "There is no file at the given path, but we expected one",
         }
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -52,7 +52,9 @@ impl RepoExt for git2::Repository {
         self.find_reference("HEAD")?
             .resolve()?
             .target()
-            .ok_or_else(|| git2::Error::from_str("HEAD reference has no target Oid").into())
+            .ok_or_else(|| {
+                git2::Error::from_str("HEAD reference has no target Oid").into()
+            })
     }
 
     fn head_commit(&self) -> error::Result<git2::Commit> {
@@ -84,7 +86,7 @@ impl RepoExt for git2::Repository {
                 .canonicalize()?
                 .parent()
                 .expect(".git/ folder should always be within the root of the repo")
-                .join(TEST_CASE_FILE_NAME)
+                .join(TEST_CASE_FILE_NAME),
         )
     }
 
@@ -113,7 +115,7 @@ pub struct TempRepo {
     // Only an `Option` so we can force its destruction before the temp dir
     // disappears under its feet.
     repo: Option<git2::Repository>,
-    _dir: Arc<tempdir::TempDir>
+    _dir: Arc<tempdir::TempDir>,
 }
 
 impl fmt::Debug for TempRepo {
@@ -153,12 +155,10 @@ impl TempRepo {
             repo.commit(Some("HEAD"), &sig, &sig, "Initial commit", &tree, &[])?;
         }
 
-        Ok(
-            TempRepo {
-                repo: Some(repo),
-                _dir: dir
-            }
-        )
+        Ok(TempRepo {
+            repo: Some(repo),
+            _dir: dir,
+        })
     }
 
     /// Create a temporary clone repository of a local upstream git repository.
@@ -169,12 +169,10 @@ impl TempRepo {
         let upstream = upstream.as_ref().to_string_lossy();
         let dir = Arc::new(tempdir::TempDir::new(prefix)?);
         let repo = git2::Repository::clone(&upstream, dir.path())?;
-        Ok(
-            TempRepo {
-                repo: Some(repo),
-                _dir: dir
-            }
-        )
+        Ok(TempRepo {
+            repo: Some(repo),
+            _dir: dir,
+        })
     }
 }
 

--- a/src/signposts.rs
+++ b/src/signposts.rs
@@ -2,7 +2,7 @@
 extern crate signpost;
 
 macro_rules! define_signpost {
-    ( $name:ident , $code:expr ) => {
+    ( $code:expr, $name:ident ) => {
         #[cfg(feature = "signpost")]
         pub struct $name(self::signpost::AutoTrace<'static>);
 
@@ -27,12 +27,13 @@ macro_rules! define_signpost {
     }
 }
 
-define_signpost!(SupervisorHandleInteresting, 100);
-define_signpost!(SupervisorNextReduction, 101);
-define_signpost!(SupervisorShutdown, 102);
-define_signpost!(SupervisorRunLoop, 103);
+define_signpost!(100, SupervisorHandleInteresting);
+define_signpost!(101, SupervisorShutdown);
+define_signpost!(102, SupervisorRunLoop);
 
-define_signpost!(WorkerGetNextReduction, 200);
-define_signpost!(WorkerJudgeInteresting, 201);
-define_signpost!(WorkerReportInteresting, 202);
-define_signpost!(WorkerTryMerging, 203);
+define_signpost!(200, WorkerGetNextReduction);
+define_signpost!(201, WorkerJudgeInteresting);
+define_signpost!(202, WorkerReportInteresting);
+define_signpost!(203, WorkerTryMerging);
+
+define_signpost!(300, ReducerNextReduction);

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -68,7 +68,7 @@ function test_reducer {
         echo "$tmp" > "$child_stdin"
 
         # Wait for it to finish generating its reduction.
-        read empty < "$child_stdout"
+        read -t 10 empty < "$child_stdout"
         if [[ "$empty" != "" ]]; then
             echo "Reducer should have written a '\n', got: '$empty'"
             exit 1


### PR DESCRIPTION
By creating an actor for each reducer, rather than having the supervisor invoke
the reducer directly, we get a few nice properties:

* There is less contention for the supervisor's time, which has largely been the
  bottleneck for many-core machines thus far.

* We can generate reductions from distinct reducers in parallel.

* We can pipeline generating reductions with testing reductions to cut down on
  time spent waiting on channels.