### PR TITLE
run 'git gc' when a worker has done 20 tests

### DIFF
--- a/src/actors/worker.rs
+++ b/src/actors/worker.rs
@@ -56,6 +56,7 @@ impl Worker {
         supervisor: Supervisor,
         logger: Logger,
         upstream: &path::Path,
+        git_gc_threshold: usize,
     ) -> error::Result<Worker> {
         logger.spawning_worker(id);
 
@@ -71,7 +72,8 @@ impl Worker {
         thread::Builder::new()
             .name(format!("preduce-worker-{}", id))
             .spawn(move || {
-                WorkerActor::run(id, me2, predicate, receiver, supervisor, logger, upstream);
+                WorkerActor::run(id, me2, predicate, receiver, supervisor, logger, upstream,
+                                 git_gc_threshold);
             })?;
 
         Ok(me)
@@ -116,6 +118,7 @@ struct WorkerActor {
     supervisor: Supervisor,
     logger: Logger,
     repo: git::TempRepo,
+    git_gc_threshold: usize,
     tests_since_gc: usize,
 }
 
@@ -154,12 +157,14 @@ impl WorkerActor {
         supervisor: Supervisor,
         logger: Logger,
         upstream: path::PathBuf,
+        git_gc_threshold: usize,
     ) {
         match {
             let supervisor2 = supervisor.clone();
             let logger2 = logger.clone();
             panic::catch_unwind(panic::AssertUnwindSafe(move || {
-                WorkerActor::try_run(id, me, predicate, incoming, supervisor2, logger2, upstream)
+                WorkerActor::try_run(id, me, predicate, incoming, supervisor2, logger2, upstream,
+                                     git_gc_threshold)
             }))
         } {
             Err(p) => {
@@ -180,6 +185,7 @@ impl WorkerActor {
         supervisor: Supervisor,
         logger: Logger,
         upstream: path::PathBuf,
+        git_gc_threshold: usize,
     ) -> error::Result<()> {
         logger.spawned_worker(id);
 
@@ -194,6 +200,7 @@ impl WorkerActor {
             supervisor: supervisor,
             logger: logger,
             repo: repo,
+            git_gc_threshold: git_gc_threshold,
             tests_since_gc: 0,
         };
 
@@ -285,7 +292,7 @@ impl Test {
         let _signpost = signposts::WorkerJudgeInteresting::new();
 
         {
-            if self.worker.tests_since_gc > 20 {
+            if self.worker.tests_since_gc > self.worker.git_gc_threshold {
                 self.worker.repo.gc()?;
                 self.worker.tests_since_gc = 0;
             }

--- a/src/bin/preduce.rs
+++ b/src/bin/preduce.rs
@@ -88,6 +88,26 @@ fn parse_args() -> clap::ArgMatches<'static> {
                      combining two interesting test cases into a third reduction.",
                 ),
         )
+        .arg(
+            clap::Arg::with_name("git_gc_threshold")
+                .short("g")
+                .long("git-gc-threshold")
+                .takes_value(true)
+                .value_name("GIT_GC_THRESHOLD")
+                .default_value("20")
+                .validator(|a| {
+                    let num = a.parse::<usize>().map_err(|e| format!("{}", e))?;
+                    if num > 0 {
+                        Ok(())
+                    } else {
+                        Err("GIT_GC_THRESHOLD must be a number greater than 0".into())
+                    }
+                })
+                .help(
+                    "Set the number of git operations performed on a repository before running \
+                     `git gc`. This prevents repository sizes from growing wihout bound.",
+                ),
+        )
         .get_matches()
 }
 
@@ -129,6 +149,10 @@ fn try_main() -> error::Result<()> {
     if args.is_present("no_merging") {
         options = options.try_merging(false);
     }
+
+    // For args with a default value, value_of will always succeed.
+    let git_gc_threshold = args.value_of("git_gc_threshold").unwrap().parse::<usize>().unwrap();
+    options = options.git_gc_threshold(git_gc_threshold);
 
     options.run()
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,9 @@ pub enum Error {
 
     /// There is no file at the given path, when we expected one.
     DoesNotExist(path::PathBuf),
+
+    /// Running `git gc` on a repository failed.
+    GitGcFailed,
 }
 
 impl fmt::Display for Error {
@@ -58,6 +61,7 @@ impl fmt::Display for Error {
             Error::DoesNotExist(ref file_path) => {
                 write!(f, "The file does not exist: {}", file_path.display())
             }
+            Error::GitGcFailed => write!(f, "Running `git gc` on a repository failed"),
         }
     }
 }
@@ -75,6 +79,7 @@ impl error::Error for Error {
                 "The initial test case did not pass the is-interesting predicate"
             }
             Error::DoesNotExist(_) => "There is no file at the given path, but we expected one",
+            Error::GitGcFailed => "Running `git gc` on a repository failed",
         }
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -160,12 +160,15 @@ impl RepoExt for git2::Repository {
     }
 
     fn gc(&self) -> error::Result<()> {
-        ::std::process::Command::new("git")
-            .args(&["gc"])
+        let status = ::std::process::Command::new("git")
+            .arg("gc")
             .current_dir(self.path())
             .stderr(Stdio::null())
             .stdout(Stdio::null())
-            .spawn()?.wait()?;
+            .status()?;
+        if !status.success() {
+            return Err(error::Error::GitGcFailed);
+        }
         Ok(())
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -8,6 +8,7 @@ use std::fs;
 use std::ops;
 use std::path;
 use std::sync::Arc;
+use std::process::Stdio;
 use tempdir;
 
 /// The file name for test cases within a git repository.
@@ -48,6 +49,8 @@ pub trait RepoExt {
         first: git2::Oid,
         second: git2::Oid,
     ) -> error::Result<Option<git2::Oid>>;
+
+    fn gc(&self) -> error::Result<()>;
 }
 
 impl RepoExt for git2::Repository {
@@ -154,6 +157,16 @@ impl RepoExt for git2::Repository {
         let commit_id = self.commit(Some("HEAD"), &sig, &sig, "merge", &tree, &parents[..])?;
         self.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))?;
         Ok(Some(commit_id))
+    }
+
+    fn gc(&self) -> error::Result<()> {
+        ::std::process::Command::new("git")
+            .args(&["gc"])
+            .current_dir(self.path())
+            .stderr(Stdio::null())
+            .stdout(Stdio::null())
+            .spawn()?.wait()?;
+        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ mod test_utils;
 use std::mem;
 use std::path;
 
+const DEFAULT_GIT_GC_THRESHOLD: usize = 20;
+
 /// A builder to configure a `preduce` run's options, and finally start the
 /// reduction process.
 ///
@@ -65,6 +67,7 @@ where
     reducers: Vec<Box<traits::Reducer>>,
     workers: usize,
     try_merging: bool,
+    git_gc_threshold: usize,
 }
 
 /// APIs for configuring options and spawning the reduction process.
@@ -108,6 +111,7 @@ where
             reducers: reducers,
             workers: num_cpus::get(),
             try_merging: true,
+            git_gc_threshold: DEFAULT_GIT_GC_THRESHOLD,
         }
     }
 
@@ -159,6 +163,13 @@ where
     /// ```
     pub fn try_merging(mut self, should_try_merging: bool) -> Options<I> {
         self.try_merging = should_try_merging;
+        self
+    }
+
+    /// Sets the number of git operations performed on a repository before
+    /// running `git gc`. This prevents runaway repository size.
+    pub fn git_gc_threshold(mut self, git_gc_threshold: usize) -> Options<I> {
+        self.git_gc_threshold = git_gc_threshold;
         self
     }
 


### PR DESCRIPTION
This keeps the worker repository size from growing too large too fast.
Ideally we'd want to parameterize the number of tests per gc, but I
don't really know how to do that.