### PR TITLE
nicely shut down children so they can clean up

### DIFF
--- a/reducers/reducer_utils.py
+++ b/reducers/reducer_utils.py
@@ -107,11 +107,10 @@ def topformflat_reducer(seed, flatten):
     if topformflat is None:
         return
 
-    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tmp_file:
+    with tempfile.NamedTemporaryFile(mode="w+") as tmp_file:
         with open(seed, "r") as in_file:
             subprocess.check_call([topformflat, str(flatten)], stdin=in_file, stdout=tmp_file)
-
-    chunking_reducer(tmp_file.name)
+        chunking_reducer(tmp_file.name)
 
 def clex_reducer(seed, clex_command):
     clex = get_clex()

--- a/src/reducers.rs
+++ b/src/reducers.rs
@@ -165,6 +165,22 @@ impl Script {
         Ok(())
     }
 
+    /// Attempt to nicely tell the child to stop by sending it an empty line to
+    /// use as the next "seed", whereupon it should exit cleanly, thus cleaning
+    /// up any resources it was using (e.g. temporary files).
+    fn shutdown_child(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            if {
+                let mut child_stdin = child.stdin.as_mut().unwrap();
+                write!(child_stdin, "\n").is_err()
+            } {
+                self.kill_child();
+            }
+            self.child_stdout = None;
+            self.out_dir = None;
+        }
+    }
+
     fn kill_child(&mut self) {
         if let Some(mut child) = self.child.take() {
             let _ = child.kill();
@@ -289,10 +305,10 @@ impl Reducer for Script {
     fn set_seed(&mut self, seed: test_case::Interesting) {
         self.seed = Some(seed);
 
-        // If we have an extant child process, kill it now. We'll start a new
+        // If we have an extant child process, shut it down now. We'll start a new
         // child process with the new seed the next time
         // `next_potential_reduction` is invoked.
-        self.kill_child();
+        self.shutdown_child();
     }
 
     fn next_potential_reduction(&mut self) -> error::Result<Option<test_case::PotentialReduction>> {

--- a/src/reducers.rs
+++ b/src/reducers.rs
@@ -171,8 +171,7 @@ impl Script {
     fn shutdown_child(&mut self) {
         if let Some(mut child) = self.child.take() {
             if {
-                let mut child_stdin = child.stdin.as_mut().unwrap();
-                write!(child_stdin, "\n").is_err()
+                write!(child.stdin.as_mut().unwrap(), "\n").and_then(|_| child.wait()).is_err()
             } {
                 self.kill_child();
             }


### PR DESCRIPTION
This deals with all the temporary files the topformflat reducers were
creating but then not cleaning up (because they were being SIGKILLed,
which immediately kills without allowing for cleanup).