### PR TITLE
add tests for and fix bug in regexp-based reducers

### DIFF
--- a/reducers/reducer_utils.py
+++ b/reducers/reducer_utils.py
@@ -189,16 +189,16 @@ def regexp_matching_reducer(seed, regexp):
             return
 
         # Write a copy of the file without the n^th matching line.
-        i = 0
+        i = -1
         found_nth_match = False
         with open(out_file_path, "w") as out_file:
             with open(seed, "r") as in_file:
                 for line in in_file:
                     if regexp.match(line.strip()):
+                        i += 1
                         if i == n:
                             found_nth_match = True
                             continue
-                        i += 1
                     out_file.write(line)
 
         n += 1

--- a/tests/expectations/blank-0
+++ b/tests/expectations/blank-0
@@ -1,0 +1,18 @@
+template <int N>
+struct Wow {
+    char such[N];
+    template <class T>
+    struct Such {
+        T t;
+
+        struct Many {
+            bool b;
+            int i;
+            char c;
+        };
+    };
+};
+
+long long beard() {
+    return 42;
+}

--- a/tests/expectations/blank-1
+++ b/tests/expectations/blank-1
@@ -1,0 +1,18 @@
+template <int N>
+struct Wow {
+    char such[N];
+
+    template <class T>
+    struct Such {
+        T t;
+        struct Many {
+            bool b;
+            int i;
+            char c;
+        };
+    };
+};
+
+long long beard() {
+    return 42;
+}

--- a/tests/expectations/blank-2
+++ b/tests/expectations/blank-2
@@ -1,0 +1,18 @@
+template <int N>
+struct Wow {
+    char such[N];
+
+    template <class T>
+    struct Such {
+        T t;
+
+        struct Many {
+            bool b;
+            int i;
+            char c;
+        };
+    };
+};
+long long beard() {
+    return 42;
+}

--- a/tests/expectations/includes-0
+++ b/tests/expectations/includes-0
@@ -1,0 +1,8 @@
+#	include <cstdlib>
+
+int main(int argc, char* argv[])
+{
+  #include <something>
+  return 0;
+  #include not even the right syntax, but it'll still get removed
+}

--- a/tests/expectations/includes-1
+++ b/tests/expectations/includes-1
@@ -1,0 +1,8 @@
+#include<stdio.h>
+
+int main(int argc, char* argv[])
+{
+  #include <something>
+  return 0;
+  #include not even the right syntax, but it'll still get removed
+}

--- a/tests/expectations/includes-2
+++ b/tests/expectations/includes-2
@@ -1,0 +1,8 @@
+#include<stdio.h>
+#	include <cstdlib>
+
+int main(int argc, char* argv[])
+{
+  return 0;
+  #include not even the right syntax, but it'll still get removed
+}

--- a/tests/expectations/includes-3
+++ b/tests/expectations/includes-3
@@ -1,0 +1,8 @@
+#include<stdio.h>
+#	include <cstdlib>
+
+int main(int argc, char* argv[])
+{
+  #include <something>
+  return 0;
+}

--- a/tests/fixtures/some-includes.cpp
+++ b/tests/fixtures/some-includes.cpp
@@ -1,0 +1,9 @@
+#include<stdio.h>
+#	include <cstdlib>
+
+int main(int argc, char* argv[])
+{
+  #include <something>
+  return 0;
+  #include not even the right syntax, but it'll still get removed
+}

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -92,6 +92,10 @@ test_preduce_run \
     ../reducers/*.py
 
 test_reducer \
+    ../reducers/blank.py \
+    fixtures/wow.cpp \
+    expectations/blank-*
+test_reducer \
     ../reducers/chunks.py \
     fixtures/lorem-ipsum.txt \
     expectations/chunks-*
@@ -111,6 +115,10 @@ test_reducer \
     ../reducers/clang-delta-remove-unused-outer-class.py \
     fixtures/wow.cpp \
     expectations/clang-delta-remove-unused-outer-class-0
+test_reducer \
+    ../reducers/includes.py \
+    fixtures/some-includes.cpp \
+    expectations/includes-*
 
 if [[ "$CI" == "false" ]]; then
     # For some reason this hangs in Travis CI...


### PR DESCRIPTION
Before this change, all regexp-based reducers would first generate a
reduction by removing all of the matching lines from the seed file. They
would then proceed to generate reductions that removed all matching
lines except the first, and then the first and second, and so on. This
changes the implementation to only remove one matching line at a time,
which I believe was the original intention. (Note that it appears the
original creduce pass_blank.pm would remove all blank lines to generate
one reduction and then remove all lines that started with '#' to
generate a second reduction.)