### PR TITLE
fix bug where balanced reducers would read stdin too much

### DIFF
--- a/reducers/reducer_utils.py
+++ b/reducers/reducer_utils.py
@@ -282,13 +282,13 @@ def balanced_reducer(seed, bracket_type):
         sys.stdout.write("\n")
         sys.stdout.flush()
 
-        out_file_path = sys.stdin.readline().strip()
-        if out_file_path == "":
-            return
         # Generate a reduction by removing the contents of the range
         # (brackets not included). This doesn't make much sense if the
         # range is (n, n + 1), so filter out that case.
         if indices[0] + 1 < indices[1]:
+            out_file_path = sys.stdin.readline().strip()
+            if out_file_path == "":
+                return
             with open(out_file_path, "w") as out_file:
                 out_file.write(contents[0:indices[0] + 1] + contents[indices[1]:])
             # Tell `preduce` we generated the reduction.


### PR DESCRIPTION
For each balanced pair, balanced reducers will skip the reduction consisting of
removing the characters between the pair's indices if the pair is of the form
(n, n+1). However, the initial implementation would have incorrectly already
read the next reduction output location from stdin, thus breaking the protocol.
This would result in hangs where the reducers would simply stop generating
reductions. The fix is simple: only read the output location if the reduction is
going to be generated.